### PR TITLE
Update develop_alefa.yml to revert slot-name to the original 'Product…

### DIFF
--- a/.github/workflows/develop_alefa.yml
+++ b/.github/workflows/develop_alefa.yml
@@ -53,6 +53,6 @@ jobs:
         uses: azure/webapps-deploy@v2
         with:
           app-name: 'Alefa'
-          slot-name: 'Development'
+          slot-name: 'Production'
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_B044A5E4D54D4BB5874E85BC2A7FB763 }}
           package: .


### PR DESCRIPTION
…ion' setting

The 'Production' setting is actually a 'Development' setting... Leaving it as-is not to mess with the already configured publish settings